### PR TITLE
Bug fix. Erase line after autofetch

### DIFF
--- a/git-prompt
+++ b/git-prompt
@@ -184,7 +184,7 @@ __git_prompt() {
 			# This avoids constant retries when offline.
 			GIT_LAST_FETCH=$(date '+%s')
 			# Overwrite line with full prompt.
-			printf "\r"
+			printf "\r\033[K"
 		    fi
 		fi
 


### PR DESCRIPTION
### Problem

When working on a branch with a long name (e.g. `task/QD-9578-analysis-endpoint-accepts-parameter-to-fill-gaps-or-replace`), the autofetch status message leaks into the final prompt.

After a command finishes, the prompt renders as:

```
task/QD-9578-analysis-en…place(҂)@obelix:g~search_backend$ ps-or-replace:fetch...
```

The extraneous `ps-or-replace:fetch...` at the tail is a remnant of the temporary fetch notification that was not fully cleared.

### How to reproduce it

The way to reproduce this bug is to trigger the autofetch. For instance, in a terminal change to a directory which have a .git repo with a long branch name.

During the autofetch the terminal renders like this:

```
sergi@obelix:~/projects$ cd search_backend
task/QD-9578-analysis-endpoint-accepts-parameter-to-fill-gaps-or-replace:fetch...
```

After autofetch the terminal renders like this:

```
sergi@obelix:~/projects$ cd search_backend
task/QD-9578-analysis-en…place@obelix:g~search_backend$ -gaps-or-replace:fetch...
```

### Root cause

During autofetch, the script prints a temporary status line using the **full** (untrimmed) branch name:

```bash
printf "${Fetch_color}${GIT_BRANCH}:fetch...\033[0m"
```

Once the fetch completes, it attempts to overwrite the message by issuing a bare carriage return:

```bash
printf "\r"
```

This moves the cursor back to column 0, and bash then renders `PS1` on top of it. However, `PS1` uses the **truncated** branch name (max 30 characters by default), so the rendered prompt is significantly shorter than the fetch message. The trailing characters of the longer fetch message are never overwritten and remain visible on screen.

### Fix

Append the ANSI escape sequence `\033[K` (Erase in Line — from cursor to end of line) immediately after the carriage return:

```bash
printf "\r\033[K"
```

This ensures the entire line is cleared before bash draws the new prompt, regardless of how long the previous fetch message was.
